### PR TITLE
FIX mobile for roulier

### DIFF
--- a/delivery_roulier_laposte/models/stock.py
+++ b/delivery_roulier_laposte/models/stock.py
@@ -130,4 +130,8 @@ class StockPicking(models.Model):
         if 'partner_firstname' in self.env.registry._init_modules \
                 and partner.firstname:
             address['firstName'] = partner.firstname
+        # because only mobile is required
+        # and phone key is used laposte roulier template
+        if address.get('mobile'):
+            address['phone'] = address.get('mobile')
         return address


### PR DESCRIPTION
### one
phone field is used in jinja template.

web service required mobile only and without that
raised message is "your mobile number is not OK" whereas it's phone which is sent


### two
manage file extension