### PR TITLE
Fix base64 carriage return errors

### DIFF
--- a/delivery_roulier/models/stock_package.py
+++ b/delivery_roulier/models/stock_package.py
@@ -4,6 +4,7 @@
 
 from functools import wraps
 import logging
+import base64
 
 from openerp import models, api
 from openerp.tools.translate import _
@@ -163,7 +164,7 @@ class StockQuantPackage(models.Model):
             'package_id': self.id,
         }
         if label.get('data'):
-            data['datas'] = label['data'].encode('base64')
+            data['datas'] = base64.b64encode(label['data'])
             data['type'] = 'binary'
         return data
 


### PR DESCRIPTION
use base64.b64encode in favor of str.encode('base64')
"".encode('base64') adds carriage returns, it may cause issues
at the decode phase