### PR TITLE
Improve should_include_customs

### DIFF
--- a/delivery_roulier_dpd/models/stock.py
+++ b/delivery_roulier_dpd/models/stock.py
@@ -5,7 +5,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 import logging
-from openerp import models, api
+from openerp import models
 from openerp.tools import DEFAULT_SERVER_DATETIME_FORMAT
 
 from datetime import datetime, timedelta

--- a/delivery_roulier_laposte/__openerp__.py
+++ b/delivery_roulier_laposte/__openerp__.py
@@ -14,6 +14,7 @@
     'depends': [
         'delivery_roulier',
         'base_phone',
+        'intrastat_base',
         # 'delivery_carrier_deposit',
     ],
     'website': 'http://www.akretion.com/',

--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -5,3 +5,4 @@ server-tools
 stock-logistics-workflow
 webkit-tools
 connector-telephony
+intrastat


### PR DESCRIPTION
Instead of relying of products, we now rely on instrastat flag
on sender and receiver countries.

It works well when shipping is from France métropole.
Other cases are not handled yet (from outre-mer) and alway
return "True"

Adds intrastat_base as dependency. Requires a module update.