### PR TITLE
Field partner_id of delivery.carrier has been dropped in v10

### DIFF
--- a/delivery_roulier_laposte/data/delivery.xml
+++ b/delivery_roulier_laposte/data/delivery.xml
@@ -2,17 +2,6 @@
 <odoo>
     <data noupdate="1">
 
-    <!-- PARTNER -->
-    <record id="partner_la_poste" model="res.partner">
-        <field name="name">La Poste</field>
-        <field name="is_company" eval="True"/>
-        <field name="customer" eval="False"/>
-        <field name="supplier" eval="True"/>
-        <field name="street">rue du colis</field>
-        <field name="zip">99999</field>
-        <field name="city">XXXXXX PFC</field>
-    </record>
-
     <!-- DELIVERY CARRIER TEMPLATE OPTION -->
     <record id="carrier_opt_tmpl_NM" model="delivery.carrier.template.option">
         <field name="name">Non Mécanisable</field>
@@ -26,9 +15,7 @@
         <field name="code">DOM</field>
         <field name="carrier_type">laposte</field>
         <field name="product_type">service</field>
-        <field name="use_detailed_pricelist" eval="1"/>
         <field name="deposit_slip" eval="True"/>
-        <field name="partner_id" ref="delivery_roulier_laposte.partner_la_poste"/>
     </record>
     <record id="DOM_laposte_carrier_opt_tmpl_NM"
             model="delivery.carrier.option">
@@ -45,9 +32,7 @@
         <field name="carrier_type">laposte</field>
         <field name="product_type">service</field>
         <field name="code">DOS</field>
-        <field name="use_detailed_pricelist" eval="1"/>
         <field name="deposit_slip" eval="True"/>
-        <field name="partner_id" ref="delivery_roulier_laposte.partner_la_poste"/>
     </record>
     <record id="DOS_laposte_carrier_opt_tmpl_NM" model="delivery.carrier.option">
         <field name="readonly_flag" eval="True"/>
@@ -91,9 +76,7 @@
         <field name="product_type">service</field>
         <field name="code">CORE</field>
         <field name="default_code">CORE</field>
-        <field name="use_detailed_pricelist" eval="1"/>
         <field name="deposit_slip" eval="True"/>
-        <field name="partner_id" ref="delivery_roulier_laposte.partner_la_poste"/>
     </record>
     <record id="CORE_laposte_carrier_opt_tmpl_NM"
             model="delivery.carrier.option">
@@ -118,9 +101,7 @@
         <field name="product_type">service</field>
         <field name="code">COM</field>
         <field name="default_code">COM</field>
-        <field name="use_detailed_pricelist" eval="1"/>
         <field name="deposit_slip" eval="True"/>
-        <field name="partner_id" ref="delivery_roulier_laposte.partner_la_poste"/>
     </record>
     <record id="COM_laposte_carrier_opt_tmpl_NM"
             model="delivery.carrier.option">
@@ -145,9 +126,7 @@
         <field name="product_type">service</field>
         <field name="code">CDS</field>
         <field name="default_code">CDS</field>
-        <field name="use_detailed_pricelist" eval="1"/>
         <field name="deposit_slip" eval="True"/>
-        <field name="partner_id" ref="delivery_roulier_laposte.partner_la_poste"/>
     </record>
     <record id="CDS_laposte_carrier_opt_tmpl_NM" model="delivery.carrier.option">
         <field name="readonly_flag" eval="True"/>
@@ -188,9 +167,7 @@
         <field name="product_type">service</field>
         <field name="default_code">CORI</field>
         <field name="code">CORI</field>
-        <field name="use_detailed_pricelist" eval="1"/>
         <field name="deposit_slip" eval="True"/>
-        <field name="partner_id" ref="delivery_roulier_laposte.partner_la_poste"/>
     </record>
     <record id="CORI_laposte_carrier_opt_tmpl_NM" model="delivery.carrier.option">
         <field name="readonly_flag" eval="True"/>
@@ -222,9 +199,7 @@
         <field name="product_type">service</field>
         <field name="code">COLI</field>
         <field name="default_code">COLI</field>
-        <field name="use_detailed_pricelist" eval="1"/>
         <field name="deposit_slip" eval="True"/>
-        <field name="partner_id" ref="delivery_roulier_laposte.partner_la_poste"/>
     </record>
     <record id="COLI_laposte_carrier_opt_tmpl_NM"
             model="delivery.carrier.option">


### PR DESCRIPTION
Fix to avoid the warning:
2018-04-16 13:51:11,243 915 WARNING o0_test3 odoo.models: delivery.carrier.create() includes unknown fields: partner_id, use_detailed_pricelist

Field partner_id of delivery.carrier was part of the "delivery" module and has been dropped in v10
Field use_detailed_pricelist of delivery.carrier was part of the "delivery" module and has been dropped in v9