### PR TITLE
[ADD] dropoff_site_number field on the partner

### DIFF
--- a/delivery_roulier/models/__init__.py
+++ b/delivery_roulier/models/__init__.py
@@ -1,3 +1,4 @@
 from . import stock_picking
 from . import stock_quant_package
 from . import stock_pack_operation
+from . import res_partner

--- a/delivery_roulier/models/res_partner.py
+++ b/delivery_roulier/models/res_partner.py
@@ -1,0 +1,13 @@
+# coding: utf-8
+# @author Pierrick Brun <pierrick.brun@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import models, fields
+
+
+class ResPartner(models.Model):
+    _inherit = 'res.partner'
+
+    dropoff_site_number = fields.Char(
+        help='the number used by the carrier to identify the dropoff site'
+    )


### PR DESCRIPTION
In order to be communicated to the carrier later.
It allows to store the dropoff locations as res.partner if needed too.