### PR TITLE
[IMP] add support for Colissimo Pickup

### DIFF
--- a/delivery_roulier/models/__init__.py
+++ b/delivery_roulier/models/__init__.py
@@ -1,3 +1,4 @@
 from . import stock_picking
 from . import stock_quant_package
 from . import stock_pack_operation
+from . import res_partner

--- a/delivery_roulier/models/res_partner.py
+++ b/delivery_roulier/models/res_partner.py
@@ -1,0 +1,13 @@
+# coding: utf-8
+# @author Pierrick Brun <pierrick.brun@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import models, fields
+
+
+class ResPartner(models.Model):
+    _inherit = 'res.partner'
+
+    dropoff_site_number = fields.Char(
+        help='the number used by the carrier to identify the dropoff site'
+    )

--- a/delivery_roulier_laposte/data/delivery.xml
+++ b/delivery_roulier_laposte/data/delivery.xml
@@ -226,5 +226,83 @@
         <!-- Pas de niveau de recommandation possible: seulement assurance -->
     </record>
 
+    <record id="delivery_carrier_A2P" model="delivery.carrier">
+        <field name="name">Colissimo Point Retrait - Relais Pickup France</field>
+        <field name="default_code">A2P</field>
+        <field name="code">A2P</field>
+        <field name="carrier_type">laposte</field>
+        <field name="product_type">service</field>
+        <field name="deposit_slip" eval="True"/>
+    </record>
+    <record id="A2P_laposte_carrier_opt_tmpl_NM" model="delivery.carrier.option">
+        <field name="readonly_flag" eval="True"/>
+        <field name="mandatory" eval="False"/>
+        <field name="by_default" eval="False"/>
+        <field name="carrier_id" ref="delivery_carrier_A2P"/>
+        <field name="tmpl_option_id" ref="delivery_roulier_laposte.carrier_opt_tmpl_NM"/>
+    </record>
+    <record id="A2P_laposte_carrier_opt_tmpl_INS" model="delivery.carrier.option">
+        <field name="readonly_flag" eval="True"/>
+        <field name="mandatory" eval="False"/>
+        <field name="by_default" eval="False"/>
+        <field name="carrier_id" ref="delivery_carrier_A2P"/>
+        <field name="tmpl_option_id" ref="delivery_roulier_option.carrier_opt_tmpl_INS"/>
+    </record>
+
+    <record id="delivery_carrier_BPR" model="delivery.carrier">
+        <field name="name">Colissimo Point Retrait - Bureau de Poste France</field>
+        <field name="default_code">BPR</field>
+        <field name="code">BPR</field>
+        <field name="carrier_type">laposte</field>
+        <field name="product_type">service</field>
+        <field name="deposit_slip" eval="True"/>
+    </record>
+    <record id="BPR_laposte_carrier_opt_tmpl_NM" model="delivery.carrier.option">
+        <field name="readonly_flag" eval="True"/>
+        <field name="mandatory" eval="False"/>
+        <field name="by_default" eval="False"/>
+        <field name="carrier_id" ref="delivery_carrier_BPR"/>
+        <field name="tmpl_option_id" ref="delivery_roulier_laposte.carrier_opt_tmpl_NM"/>
+    </record>
+    <record id="BPR_laposte_carrier_opt_tmpl_INS" model="delivery.carrier.option">
+        <field name="readonly_flag" eval="True"/>
+        <field name="mandatory" eval="False"/>
+        <field name="by_default" eval="False"/>
+        <field name="carrier_id" ref="delivery_carrier_BPR"/>
+        <field name="tmpl_option_id" ref="delivery_roulier_option.carrier_opt_tmpl_INS"/>
+    </record>
+
+    <record id="delivery_carrier_CMT" model="delivery.carrier">
+        <field name="name">Colissimo Point Retrait - Relais Pickup Europe</field>
+        <field name="default_code">CMT</field>
+        <field name="code">CMT</field>
+        <field name="carrier_type">laposte</field>
+        <field name="product_type">service</field>
+        <field name="deposit_slip" eval="True"/>
+    </record>
+    <record id="CMT_laposte_carrier_opt_tmpl_NM" model="delivery.carrier.option">
+        <field name="readonly_flag" eval="True"/>
+        <field name="mandatory" eval="False"/>
+        <field name="by_default" eval="False"/>
+        <field name="carrier_id" ref="delivery_carrier_CMT"/>
+        <field name="tmpl_option_id" ref="delivery_roulier_laposte.carrier_opt_tmpl_NM"/>
+    </record>
+
+    <record id="delivery_carrier_BDP" model="delivery.carrier">
+        <field name="name">Colissimo Point Retrait - Bureau de Poste Europe</field>
+        <field name="default_code">BDP</field>
+        <field name="code">BDP</field>
+        <field name="carrier_type">laposte</field>
+        <field name="product_type">service</field>
+        <field name="deposit_slip" eval="True"/>
+    </record>
+    <record id="BDP_laposte_carrier_opt_tmpl_NM" model="delivery.carrier.option">
+        <field name="readonly_flag" eval="True"/>
+        <field name="mandatory" eval="False"/>
+        <field name="by_default" eval="False"/>
+        <field name="carrier_id" ref="delivery_carrier_BDP"/>
+        <field name="tmpl_option_id" ref="delivery_roulier_laposte.carrier_opt_tmpl_NM"/>
+    </record>
+
 </data>
 </odoo>

--- a/delivery_roulier_laposte/models/stock_picking.py
+++ b/delivery_roulier_laposte/models/stock_picking.py
@@ -104,6 +104,7 @@ class StockPicking(models.Model):
             dict
         """
         address = self._roulier_convert_address(partner) or {}
+        address['companyName'] = address.get('company')
         # get_split_adress from partner_helper module
         streets = partner._get_split_address(3, 38)
         address['street'], address['street2'], address['street3'] = streets

--- a/delivery_roulier_laposte/models/stock_quant_package.py
+++ b/delivery_roulier_laposte/models/stock_quant_package.py
@@ -23,6 +23,8 @@ CUSTOMS_MAP = {
     'return': 6,
 }
 
+PICKUP_CARRIER_CODES = ['A2P', 'BPR', 'ACP', 'CDI', 'CMT', 'BDP', 'PCS']
+
 
 class StockQuantPackage(models.Model):
     _inherit = 'stock.quant.package'
@@ -43,7 +45,14 @@ class StockQuantPackage(models.Model):
             calc_package_price() * 100  # totalAmount is in centimes
         )
         request['service']['returnTypeChoice'] = 3  # do not return to sender
+        if picking.carrier_code in PICKUP_CARRIER_CODES:
+            request['parcels'][0]['pickupLocationId'] = \
+                self._laposte_dropoff_site(picking)
         return request
+
+    @api.multi
+    def _laposte_dropoff_site(self, picking):
+        return picking.partner_id.dropoff_site_number
 
     @api.multi
     def _laposte_get_customs(self, picking):


### PR DESCRIPTION
As long as the dropoff_site_number is correct on the shipping address (partner), roulier will be able to generate labels for colissimo pickups.

depends on #121 