### PR TITLE
[FIX] use shipping weight if defined (more accurate)

### DIFF
--- a/delivery_roulier/models/stock_quant_package.py
+++ b/delivery_roulier/models/stock_quant_package.py
@@ -170,7 +170,7 @@ class StockQuantPackage(models.Model):
     @api.multi
     def _roulier_get_parcel(self, picking):
         self.ensure_one()
-        weight = self.weight
+        weight = self.shipping_weight or self.weight
         parcel = {
             'weight': weight,
             'reference': self.name


### PR DESCRIPTION
now : use weight calculated by the ERP (sum of the products weights)

after : use weight manually entered if possible. It is more accurate and makes sure the weight of the package itself is taken into account.