### PR TITLE
Refactore base_delivery_carrier_label to improve compatibility with n…

### DIFF
--- a/base_delivery_carrier_label/models/delivery_carrier.py
+++ b/base_delivery_carrier_label/models/delivery_carrier.py
@@ -8,13 +8,15 @@ from odoo import fields, models
 class DeliveryCarrier(models.Model):
     _inherit = "delivery.carrier"
 
-    delivery_type = fields.Selection()
     available_option_ids = fields.One2many(
         comodel_name="delivery.carrier.option",
         inverse_name="carrier_id",
         string="Option",
         context={"active_test": False},
     )
+
+    def alternative_send_shipping(self, pickings):
+        return {}
 
     def default_options(self):
         """ Returns default and available options for a carrier """
@@ -28,6 +30,16 @@ class DeliveryCarrier(models.Model):
         """Handle labels and  if we have them. Expected format is {'labels': [{}, ...]}
         The dicts are input for stock.picking#attach_label"""
         result = super().send_shipping(pickings)
+        # We could want to generate labels calling a method that does not depend
+        # on one specific delivery_type.
+        # For instance, if we want to generate a default label in case there are not
+        # carrier
+        # we may want to call another method not based on any delivery_type.
+        # or at the contrary, we could call a common method for multiple delivery_type
+        # for instance, in delivery_roulier, the same method is always called for any
+        # carrier implemented in roulier lib.
+        if result is None:
+            result = self.alternative_send_shipping(pickings)
         for result_dict, picking in zip(result, pickings):
             for label in result_dict.get("labels", []):
                 picking.attach_shipping_label(label)

--- a/base_delivery_carrier_label/readme/DESCRIPTION.rst
+++ b/base_delivery_carrier_label/readme/DESCRIPTION.rst
@@ -1,3 +1,4 @@
-This module adds a button on delivery orders to generate a label as an
-attachement. This module doesn't do anything by itself, it serves as a
+This module adds some function and generic stuff to help for carrier label generation.
+For example it adds the concept of option on carriers that can differ depending on the picking or class to store carrier accounts
+This module doesn't do anything by itself, it serves as a
 base module for other carrier-specific modules.

--- a/base_delivery_carrier_label/readme/USAGE.rst
+++ b/base_delivery_carrier_label/readme/USAGE.rst
@@ -1,12 +1,26 @@
 ** How does it works ? **
 
 
-In picking UI a button "Shipping label" trigger label generation
-calling `action_generate_carrier_label()` in models/stock.picking.py
+In picking UI a button "Send to shipper" trigger label generation
+calling `send_to_shipper()` in models/stock.picking.py
 
 
 ** How to implement my own carrier ? **
 
 
-Override `generate_shipping_labels()` which is called by previous method
-in the same file.
+Define a method `carrier_delivery_type_send_shipping()` which is called by _send_shipping native method.
+Make it return a list of dict of this form :
+
+.. code-block:: python
+
+  {
+      "exact_price": price,
+      "tracking_number": 'number'
+      "labels": [{
+          "package_id": package_id,
+          "name": filename,
+          "datas": file_content (base64),
+          "file_type": extension,
+          "tracking_number": package_number
+      }]
+  }

--- a/base_delivery_carrier_label/tests/carrier_label_case.py
+++ b/base_delivery_carrier_label/tests/carrier_label_case.py
@@ -17,11 +17,15 @@ class CarrierLabelCase(TransactionCase):
         """Create a sale order and deliver the picking"""
         self.order = self.env["sale.order"].create(self._sale_order_data())
         for product in self.order.mapped("order_line.product_id"):
-            self.env['stock.quant'].with_context(inventory_mode=True).create({
-                "product_id": product.id,
-                'location_id': self.order.warehouse_id.lot_stock_id.id,
-                'inventory_quantity': sum(self.order.mapped("order_line.product_uom_qty")),
-            })
+            self.env["stock.quant"].with_context(inventory_mode=True).create(
+                {
+                    "product_id": product.id,
+                    "location_id": self.order.warehouse_id.lot_stock_id.id,
+                    "inventory_quantity": sum(
+                        self.order.mapped("order_line.product_uom_qty")
+                    ),
+                }
+            )
         self.order.action_confirm()
         self.picking = self.order.picking_ids
         self.picking.write(self._picking_data())
@@ -80,5 +84,5 @@ class CarrierLabelCase(TransactionCase):
 
     def test_labels(self):
         """Test if labels are created by the button"""
-        self.picking.action_generate_carrier_label()
+        self.picking.send_to_shipper()
         self._assert_labels()

--- a/base_delivery_carrier_label/tests/test_get_weight.py
+++ b/base_delivery_carrier_label/tests/test_get_weight.py
@@ -115,7 +115,7 @@ class TestGetWeight(TransactionCase):
                     "result_package_id": package.id,
                 },
             )
-        package.total_weight = 1542.0
+        package.shipping_weight = 1542.0
         # end of prepare data
 
         # test operation.get_weight()
@@ -126,7 +126,7 @@ class TestGetWeight(TransactionCase):
             )
 
         # test package.weight
-        self.assertEqual(package.weight, package.total_weight)
+        self.assertEqual(package.weight, package.shipping_weight)
 
     def test_get_weight_with_qty(self):
         """Ensure qty are taken in account."""

--- a/base_delivery_carrier_label/views/stock.xml
+++ b/base_delivery_carrier_label/views/stock.xml
@@ -6,16 +6,6 @@
         <field name="model">stock.picking</field>
         <field name="inherit_id" ref="delivery.view_picking_withcarrier_out_form" />
         <field name="arch" type="xml">
-            <field name="state" position="before">
-                <button
-                    name="action_generate_carrier_label"
-                    help="Create Shipping Label 🚚"
-                    attrs="{'invisible': [('show_label_button', '!=', True)]}"
-                    string="Shipping Label 🚚"
-                    type="object"
-                />
-                <field name="show_label_button" invisible="1" />
-            </field>
             <xpath expr="//page//field[@name='carrier_id']" position="after">
                 <field name="carrier_code" />
             </xpath>


### PR DESCRIPTION
…ative way to generate labels

- Remove action_generate_carrier_label button in favor on native send_to_shipper button
- Remove show_label_button field as we now have only one button to display
- Avoid generating label if a tracking ref is already set on picking
- remove total weight on packages as the native shipping weight should do the same job
- Add hook to be able to generate label with method not delivery type specific